### PR TITLE
update of the sequelize link in README of day1 activity to a active doc

### DIFF
--- a/day1/README.md
+++ b/day1/README.md
@@ -4,7 +4,7 @@
 
 - setup project
 - clone to your github
-- Read the documentation https://sequelize.org/v7/manual/getting-started.html
+- Read the documentation https://sequelize.org/docs/v6/getting-started/
 - Setup the following Models in models folder. Make sure tables made by sequelize:
 
 ```

--- a/day1/README.md
+++ b/day1/README.md
@@ -4,7 +4,7 @@
 
 - setup project
 - clone to your github
-- Read the documentation https://sequelize.org/docs/v6/getting-started/
+- Read the documentation https://sequelize.org/docs/v7/getting-started/
 - Setup the following Models in models folder. Make sure tables made by sequelize:
 
 ```


### PR DESCRIPTION
The link to [sequelize](https://sequelize.org/v7/manual/getting-started.html) in the README of day onw was returning page not found, so I updates it to an active link.